### PR TITLE
Bullet damage with more changes

### DIFF
--- a/Assets/Resources/Prefabs/Enemies/QuarterRest.prefab
+++ b/Assets/Resources/Prefabs/Enemies/QuarterRest.prefab
@@ -104,5 +104,5 @@ MonoBehaviour:
   _damageType: 1
   _damage: 10
   _moveTime: 0.5
-  _resistance: 1
+  _resistance: 2
   _vinylDrop: 16

--- a/Assets/Resources/Prefabs/Pruebas/PruebaBala.prefab
+++ b/Assets/Resources/Prefabs/Pruebas/PruebaBala.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7796486985453749290
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Towers/DrumTower.prefab
+++ b/Assets/Resources/Prefabs/Towers/DrumTower.prefab
@@ -105,6 +105,6 @@ MonoBehaviour:
   _minDamage: 8
   _MaxDamage: 15
   _range: 2
-  _bulletPrefab: {fileID: 0}
+  _bulletPrefab: {fileID: -5515273298982796374, guid: 60f6c5c95da37be42abe0a31b33fd6d4, type: 3}
   _price: 130
   _timeForProjectile: 0.1

--- a/Assets/Resources/Prefabs/Towers/PianoTower.prefab
+++ b/Assets/Resources/Prefabs/Towers/PianoTower.prefab
@@ -105,6 +105,6 @@ MonoBehaviour:
   _minDamage: 6
   _MaxDamage: 11
   _range: 1
-  _bulletPrefab: {fileID: 0}
+  _bulletPrefab: {fileID: -5515273298982796374, guid: 60f6c5c95da37be42abe0a31b33fd6d4, type: 3}
   _price: 110
   _timeForProjectile: 0.1

--- a/Assets/Resources/Prefabs/Towers/TrumpetTower 1.prefab
+++ b/Assets/Resources/Prefabs/Towers/TrumpetTower 1.prefab
@@ -105,6 +105,6 @@ MonoBehaviour:
   _minDamage: 9
   _MaxDamage: 17
   _range: 1
-  _bulletPrefab: {fileID: 0}
+  _bulletPrefab: {fileID: -5515273298982796374, guid: 60f6c5c95da37be42abe0a31b33fd6d4, type: 3}
   _price: 95
   _timeForProjectile: 0.1

--- a/Assets/Resources/Prefabs/Towers/ViolinTower.prefab
+++ b/Assets/Resources/Prefabs/Towers/ViolinTower.prefab
@@ -105,6 +105,6 @@ MonoBehaviour:
   _minDamage: 4
   _MaxDamage: 6
   _range: 2
-  _bulletPrefab: {fileID: 0}
+  _bulletPrefab: {fileID: -5515273298982796374, guid: 60f6c5c95da37be42abe0a31b33fd6d4, type: 3}
   _price: 70
   _timeForProjectile: 0.1

--- a/Assets/Src/Gameplay/Enemies/AEnemy.cs
+++ b/Assets/Src/Gameplay/Enemies/AEnemy.cs
@@ -12,11 +12,13 @@ namespace Gameplay.Enemies
 {
     public abstract class AEnemy : MonoBehaviour
     {
+        [SerializeField] const float RESISTANCE_MULTIPLAYER = 0.5f;
+
         [SerializeField] protected int _health;
-        [SerializeField] protected DamageType _damageType;   //Melee, Range, Contact
+        [SerializeField] protected EnemyDamageType _damageType;   //Melee, Range, Contact
         [SerializeField] protected int _damage;
         [SerializeField] protected float _moveTime = 0.5f;
-        [SerializeField] protected Resistance _resistance;   //None, String, Percussion or Hybrid
+        [SerializeField] protected DamageType _resistance;   //None, String, Percussion or Hybrid
         [SerializeField] protected int _vinylDrop = 0;
 
         protected int _path = 0;    
@@ -28,6 +30,7 @@ namespace Gameplay.Enemies
         protected RhythmManager _rhythmManager;
 
 
+        #region Starting methods
         public void Start()
         {
             ServiceLocatorSubsystem.SubscribeToInitialice(TakeReferences);
@@ -51,30 +54,19 @@ namespace Gameplay.Enemies
 
         protected abstract void SubscribeToRhythm();
 
-
         public void Init(int path)
         {
             _path = path;
             _index = 0;
         }
+        #endregion
 
-        public void Attack() {
-            Debug.Log("En metodo atacar");
-
-            Dancer.Instance.TakeDamage(_damage);
-        }
-        public void TakeDamage() { }
+        #region Getters and setters
 
         public int GetDrop()
         {
             return _vinylDrop;
         }
-        protected abstract void OnRhythmUpdate();
-
-        /// <summary>
-        /// Must desubscribe to the delegate of his rhythm disable the gameObject and invoke the onDeath delegate
-        /// </summary>
-        protected abstract void Death();
 
         public Vector3Int GetTile()
         {
@@ -86,6 +78,31 @@ namespace Gameplay.Enemies
             int pathTilesCount = _worldManager.GetTileCount(_path);
             return pathTilesCount - _index;
         }
+        #endregion
+
+        #region Other methods
+        public void Attack() {
+            Debug.Log("En metodo atacar");
+
+            Dancer.Instance.TakeDamage(_damage);
+        }
+        public void TakeDamage(DamageType type, int damageToTake) 
+        {
+            if (_resistance == type) _health = (int)Mathf.Round(_health - damageToTake * RESISTANCE_MULTIPLAYER);
+            else _health -= damageToTake;
+        }
+        #endregion
+
+        #region Abstract Methods
+        protected abstract void OnRhythmUpdate();
+
+        /// <summary>
+        /// Must desubscribe to the delegate of his rhythm disable the gameObject and invoke the onDeath delegate
+        /// </summary>
+        protected abstract void Death();
+
+        #endregion
+
         /// <summary>
         /// Moves the enemy to the next tile with one animation using the easing function of the parameter delegate or a lerp if is null
         /// </summary>
@@ -131,19 +148,12 @@ namespace Gameplay.Enemies
         }
     }
 
-    public enum DamageType
+    public enum EnemyDamageType
     {
         Melee,
         Range,
         Contact
     }
 
-    public enum Resistance
-    {
-        None,
-        String,
-        Percussion,
-        Hybrid
-    }
 }
 

--- a/Assets/Src/Gameplay/Enemies/EighthNote.cs
+++ b/Assets/Src/Gameplay/Enemies/EighthNote.cs
@@ -25,7 +25,7 @@ namespace Gameplay.Enemies
         protected override void Death()
         {
             _isAlive = false;
-            _rhythmManager.onQuarter -= OnRhythmUpdate;
+            _rhythmManager.onEighth -= OnRhythmUpdate;
             onDeath.Invoke(this);
             gameObject.SetActive(false);
         }

--- a/Assets/Src/Gameplay/Enemies/HalfNote.cs
+++ b/Assets/Src/Gameplay/Enemies/HalfNote.cs
@@ -25,7 +25,7 @@ namespace Gameplay.Enemies
         protected override void Death()
         {
             _isAlive = false;
-            _rhythmManager.onQuarter -= OnRhythmUpdate;
+            _rhythmManager.onHalf -= OnRhythmUpdate;
             onDeath.Invoke(this);
             gameObject.SetActive(false);
         }

--- a/Assets/Src/Gameplay/Enemies/QuarterNote.cs
+++ b/Assets/Src/Gameplay/Enemies/QuarterNote.cs
@@ -15,7 +15,6 @@ namespace Gameplay.Enemies
         protected override void SubscribeToRhythm()
         {
             _rhythmManager.onQuarter += OnRhythmUpdate;
-            
         }
 
         protected override void OnRhythmUpdate()

--- a/Assets/Src/Gameplay/Enemies/TrebleClefNote.cs
+++ b/Assets/Src/Gameplay/Enemies/TrebleClefNote.cs
@@ -25,7 +25,7 @@ namespace Gameplay.Enemies
         protected override void Death()
         {
             _isAlive = false;
-            _rhythmManager.onQuarter -= OnRhythmUpdate;
+            _rhythmManager.onMeasure -= OnRhythmUpdate;
             onDeath.Invoke(this);
             gameObject.SetActive(false);
         }

--- a/Assets/Src/Gameplay/Enemies/WholeNote.cs
+++ b/Assets/Src/Gameplay/Enemies/WholeNote.cs
@@ -25,7 +25,7 @@ namespace Gameplay.Enemies
         protected override void Death()
         {
             _isAlive = false;
-            _rhythmManager.onQuarter -= OnRhythmUpdate;
+            _rhythmManager.onWhole -= OnRhythmUpdate;
             onDeath.Invoke(this);
             gameObject.SetActive(false);
         }

--- a/Assets/Src/Gameplay/Towers/ATower.cs
+++ b/Assets/Src/Gameplay/Towers/ATower.cs
@@ -1,4 +1,4 @@
-using Gameplay.Enemies;
+﻿using Gameplay.Enemies;
 using Gameplay.World;
 using Gameplay.Waves;
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Utilities.ObjectPool;
 using Utilities.ServiceLocator;
+using System.Collections;
 
 namespace Gameplay.Towers
 {
@@ -15,6 +16,9 @@ namespace Gameplay.Towers
     /// </summary>
     public abstract class ATower : MonoBehaviour
     {
+        [SerializeField] const float PRICEMULTIPLIER = 0.7f;
+        [SerializeField] const int MAX_LEVEL = 2;
+
         [SerializeField] protected int _level;
         [SerializeField] protected DamageType _damageType; // String, Percussion, Hybrid
         [SerializeField] protected int _minDamage;   //The damage the towers can do is between two values: minDamage and maxDamage
@@ -22,38 +26,20 @@ namespace Gameplay.Towers
         [SerializeField] protected int _range;
         [SerializeField] protected Bullet _bulletPrefab; // Must be one that have Bullet Component  
         [SerializeField] protected int _price;
+        [SerializeField] protected float _timeForProjectile = 0.1f; // Time of projectile to reach the target
+        protected bool _isEnabled = true;
 
-        [SerializeField] protected double _timeForProjectile = 0.1; // Time of projectile to reach the target
         protected IPoolManager _poolManager;
-        protected WaveManager _waveManager;
-
-        
         protected Vector3Int _positionInWorldCell;
 
         #region Services references
+        protected WaveManager _waveManager;
         protected WorldManager _worldManager;
         #endregion
 
         public Func<List<AEnemy>, Vector3Int, int, List<AEnemy>> focusType;
 
-        public int GetPrice()
-        {
-            return _price;
-        }
-
-        // BALANCEAR EL SELLING PRICE
-        public int GetSellingPrice()
-        {
-            return (int)Mathf.Round((float)(_price * 0.7));
-        }
-
-        public void Improve()
-        {
-            // TO DO
-            // DEBERIA AUMENTAR UNA STAT O ALGO ASI, 
-            // DEBERIA AUMENTAR EL PRECIO - PORQUE ES LO QUE CUESTA LA MEJORA
-            // A LO MEJOR UNA VARIABLE QUE GUARDE EL NIVEL
-        }
+        #region Starting methods
         public void Start()
         {
             ServiceLocatorSubsystem.SubscribeToInitialice(Init);
@@ -62,7 +48,7 @@ namespace Gameplay.Towers
         private void Init()
         {
             _worldManager = ServiceLocatorSubsystem.Instance.GetService<WorldManager>();
-            if (_worldManager == null )
+            if (_worldManager == null)
             {
                 Debug.LogError("ATower::Init: The world manager is null");
                 return;
@@ -71,25 +57,86 @@ namespace Gameplay.Towers
             _poolManager = new PoolManager();
             _poolManager.RegisterPool<Bullet>(new ObjectPool<Bullet>(_bulletPrefab.GetComponent<Bullet>()));
         }
+        #endregion
 
-        public abstract void Disable(); // call it when disable the tower (just for sound and animations)
-        public abstract void Enable(); // call it when Enable the tower (just for sound and animations)
-        public abstract void OnRhythmHit(); // The callback when the user taps correctly, not callback of this type if not correct
+        #region Getters and setters
 
-        public void VisualAttack(AEnemy enemy)   //call it when the user taps correctly
+        public int GetPrice()
         {
-            Debug.Log("Estamos en VISUAL ATACK");
-            Bullet bullet =_poolManager.Get<Bullet>();
+            return _price;
+        }
+
+        public int GetSellingPrice()
+        {
+            return (int)Mathf.Round((float)(_price * PRICEMULTIPLIER * _level));
+        }
+        
+        public int GetDamage()
+        {
+            if (_level == 1) return _minDamage;
+            else return _MaxDamage;
+        }
+
+        public bool IsMaxLevel()
+        {
+            return _level == MAX_LEVEL;
+        }
+        #endregion
+
+        #region Other methods
+        public virtual void Disable() // call it when disable the tower (just for sound and animations)
+        {
+            SpriteRenderer sprite = GetComponent<SpriteRenderer>();
+            _isEnabled = false;
+            sprite.color = Color.red;
+        }
+        public virtual void Enable() // call it when Enable the tower (just for sound and animations)
+        {
+            SpriteRenderer sprite = GetComponent<SpriteRenderer>();
+            _isEnabled = true;
+            sprite.color = Color.white;
+        }
+        public virtual void OnRhythmHit() // The callback when the user taps correctly, not callback of this type if not correct
+        {
+            Attack();
+            StartCoroutine(TestThing());
+        }
+        public void Attack()   //call it when the user taps correctly
+        {
+            List<AEnemy> enemies = _waveManager.GetEnemiesList();
+            if (enemies == null || enemies.Count == 0) return;
+
+            List<AEnemy> objectives = focusType(enemies, _positionInWorldCell, _range);
+            if (objectives == null || objectives.Count == 0) return;
+
+            Bullet bullet = _poolManager.Get<Bullet>();
 
             Vector3 from = transform.position;
-            bullet.Shot(from, enemy, 5f, _poolManager);
+            bullet.Shot(from, objectives, _timeForProjectile, _poolManager, _damageType, GetDamage());
         }
+        public void Improve()
+        {
+            _level++;
+            _price = (int)(PRICEMULTIPLIER * _price);
+        }
+        #endregion
+
+        #region Corutines
+
+        private IEnumerator TestThing()
+        {
+            gameObject.GetComponent<SpriteRenderer>().color = Color.green;
+
+            float t = 0.0f;
+            while (t < 0.25f)
+            {
+                t += Time.deltaTime;
+                yield return null;
+            }
+            gameObject.GetComponent<SpriteRenderer>().color = Color.white;
+        }
+        #endregion
+
     }
 
-    public enum DamageType
-    {
-        String,
-        Percussion,
-        Hybrid
-    }
 }

--- a/Assets/Src/Gameplay/Towers/SpecificTowers/DrumTower.cs
+++ b/Assets/Src/Gameplay/Towers/SpecificTowers/DrumTower.cs
@@ -11,41 +11,11 @@ namespace Gameplay.Towers.SpecificTowers
             spriteRenderer = GetComponent<SpriteRenderer>();
             focusType = FocusStrategies.AreaAttack;
         }
-        new void Start()
-        {
-            base.Start();
-            focusType = FocusStrategies.AreaAttack;
-            _damageType = DamageType.Percussion;    
-            _minDamage = 8; 
-            _MaxDamage = 15;
-            _range = 2;  
-        }
 
         void LateUpdate()
         {
             //Lower is, higher appear
             spriteRenderer.sortingOrder = Mathf.RoundToInt(-transform.position.y * 100);
-        }
-
-        public override void Disable()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override void Enable()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override void OnRhythmHit()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        // Update is called once per frame
-        void Update()
-        {
-
         }
     }
 }

--- a/Assets/Src/Gameplay/Towers/SpecificTowers/PianoTower.cs
+++ b/Assets/Src/Gameplay/Towers/SpecificTowers/PianoTower.cs
@@ -8,7 +8,6 @@ namespace Gameplay.Towers.SpecificTowers
 {
     public class PianoTower : ATower
     {
-        private bool isEnabled = true;
         private SpriteRenderer spriteRenderer; //Prevent towers from overlapping incorrectly
 
         void Awake()
@@ -17,85 +16,11 @@ namespace Gameplay.Towers.SpecificTowers
             focusType = FocusStrategies.FirstEnemy;
         }
 
-        new void Start()
-        {
-            base.Start();
-            _damageType = DamageType.Hybrid;    
-            _minDamage = 6;
-            _MaxDamage = 11;
-            _range = 1;  
-        }
-
         void LateUpdate()
         {
             //Lower is, higher appear
             spriteRenderer.sortingOrder = Mathf.RoundToInt(-transform.position.y * 100);
-        }
-
-        public override void Disable()
-        {
-            SpriteRenderer sprite = GetComponent<SpriteRenderer>();
-            isEnabled = false;
-            sprite.color = Color.red;
-        }
-
-        public override void Enable()
-        {
-            SpriteRenderer sprite = GetComponent<SpriteRenderer>();
-            isEnabled = true;
-            sprite.color = Color.white;
-        }
-
-        public override void OnRhythmHit()
-        {
-            //StartCoroutine(Shoot());
-            StartCoroutine(TestThing());
-        }
-
-        private IEnumerator TestThing()
-        {
-            gameObject.GetComponent<SpriteRenderer>().color = Color.green;
-
-            float t = 0.0f;
-            while (t < 0.25f)
-            {
-                t += Time.deltaTime;
-                yield return null;
-            }
-            gameObject.GetComponent<SpriteRenderer>().color = Color.white;
-        }
-
-        // TODO: Change to actual shoot, just for alpha test
-        private IEnumerator Shoot()
-        {
-            float t = 0.0f;
-            List<AEnemy> enemies = _waveManager.GetEnemiesList();
-            if (enemies ==null || enemies.Count == 0)
-            {
-                yield return null;
-            }
-            List<AEnemy> objectives = focusType(enemies, _positionInWorldCell, _range);
-            if (objectives == null || objectives.Count == 0)
-            {
-                yield return null;
-            }
-            AEnemy enemy = objectives[0];
-
-            VisualAttack(enemy);
-            //LLAMAR A FUNCION DE HACERSE DA�O DE LOS ENEMIGOS
-            //DEJAMOS ESTO POR AHORA PARA SABER CUANDO SI SE DEBE DISPARAR Y SI ESTA SUCEDIENDO
-            SpriteRenderer sprite = GetComponent<SpriteRenderer>();
-
-            sprite.color = Color.green;
-            
-            while (t < _timeForProjectile)
-            {
-                t += Time.deltaTime;
-                yield return null;
-            }
-
-            if (isEnabled) sprite.color = Color.white;
-        }
+        }       
 
     }
 

--- a/Assets/Src/Gameplay/Towers/SpecificTowers/TrumpetTower.cs
+++ b/Assets/Src/Gameplay/Towers/SpecificTowers/TrumpetTower.cs
@@ -6,7 +6,6 @@ namespace Gameplay.Towers.SpecificTowers
 {
     public class TrumpetTower : ATower
     {
-        private List<AEnemy> enemies;
         private SpriteRenderer spriteRenderer; //Prevent towers from overlapping incorrectly
 
         void Awake()
@@ -15,41 +14,10 @@ namespace Gameplay.Towers.SpecificTowers
             focusType = FocusStrategies.FirstEnemy;
         }
 
-        new void Start()
-        {
-            base.Start();
-            
-            _damageType = DamageType.Percussion;    
-            _minDamage = 9;
-            _MaxDamage = 17;
-            _range = 1;  
-        }
-
         void LateUpdate()
         {
             //Lower is, higher appear
             spriteRenderer.sortingOrder = Mathf.RoundToInt(-transform.position.y * 100);
-        }
-
-        public override void Disable()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override void Enable()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override void OnRhythmHit()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        // Update is called once per frame
-        void Update()
-        {
-
         }
     }
 }

--- a/Assets/Src/Gameplay/Towers/SpecificTowers/ViolinTower.cs
+++ b/Assets/Src/Gameplay/Towers/SpecificTowers/ViolinTower.cs
@@ -12,17 +12,6 @@ namespace Gameplay.Towers.SpecificTowers
             spriteRenderer = GetComponent<SpriteRenderer>();
             focusType = FocusStrategies.FirstEnemy;
         }
-
-        new void Start()
-        {
-            base.Start();
-             
-            _damageType = DamageType.String;    
-            _minDamage=4;
-            _MaxDamage=6;
-            _range = 2;  
-
-        }
         
         void LateUpdate()
         {
@@ -30,26 +19,6 @@ namespace Gameplay.Towers.SpecificTowers
             spriteRenderer.sortingOrder = Mathf.RoundToInt(-transform.position.y * 100);
         }
 
-        public override void Disable()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override void Enable()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override void OnRhythmHit()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        // Update is called once per frame
-        void Update()
-        {
-
-        }
     }
 }
 

--- a/Assets/Src/Gameplay/World/Bullet.cs
+++ b/Assets/Src/Gameplay/World/Bullet.cs
@@ -1,10 +1,12 @@
 using Gameplay.Enemies;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.U2D;
 using Utilities.ObjectPool;
 
-namespace Gameplay.World {
+namespace Gameplay.World
+{
     public class Bullet : APoolableObject
     {
         /**
@@ -23,12 +25,12 @@ namespace Gameplay.World {
         }
         /**/
 
-        public void Shot(Vector3 from, AEnemy enemy, float dur, IPoolManager pool)
+        public void Shot(Vector3 from, List<AEnemy> enemy, float dur, IPoolManager pool, DamageType damageType, int damage)
         {
             Debug.Log("Bullets::Shot: Reached");
             transform.position = from;
 
-            StartCoroutine(BulletMovement(enemy, dur, pool));
+            StartCoroutine(BulletMovement(enemy, dur, pool, damageType, damage));
         }
 
         /// <summary>
@@ -38,9 +40,10 @@ namespace Gameplay.World {
         /// <param name="dur"> must be > 0 </param>
         /// <param name="pool"></param>
         /// <returns></returns>
-        private IEnumerator BulletMovement(AEnemy enemy, float dur, IPoolManager pool)
+        private IEnumerator BulletMovement(List<AEnemy> enemyList, float dur, IPoolManager pool, DamageType damageType, int damage)
         {
             Debug.Log("Bullet::BulletMovement: Start the movement of the bullet");
+            AEnemy enemy = enemyList[0];
             Vector3 start = transform.position;
             float time = 0f;
             while (time < dur)
@@ -51,7 +54,12 @@ namespace Gameplay.World {
                 yield return null;
             }
             pool.Release(this);
+            DamageEnemies(enemyList, damageType, damage);
         }
 
+        private void DamageEnemies(List<AEnemy> enemyList, DamageType damageType, int damage)
+        {
+            foreach (AEnemy enemy in enemyList) enemy.TakeDamage(damageType, damage);
+        }
     }
 }


### PR DESCRIPTION
- There were a few damag type enums, now there its just one and the Enemy Damage Type (meele range or something else)
- Added the bullet prefab to turrets and activated it
- Fixed a bug, when an Enemy prefab dies, now it unsuscribe from the correct rhythm
- Added a few constants for multiplayer
- Moved a few methods to ATower from the children. Since they were all doing that actions the same way now its in the parent.
- Deleted the start methods from the towers (they are not needed there)
- Rearranged AEnemny and ATower with regions.
- Bullets now deal damage. The method its now into the bullet class.
- Bullet recives the enemy list instead of only one enemy. Also recives the damage type and the amount. When the corutine ends the take damage its called for every enemy,
- Compressed the Atower methods related to shoot.